### PR TITLE
Use sprites instead of tileSprites

### DIFF
--- a/resources/assets/js/lib/Maps/DarkForest.js
+++ b/resources/assets/js/lib/Maps/DarkForest.js
@@ -42,7 +42,7 @@ export function createOverlays() {
 
 export function create() {
   this.game.world.setBounds(0, 0, WORLD_WIDTH, WORLD_HEIGHT)
-  this.game.add.sprite(0, 0, WORLD_WIDTH, WORLD_HEIGHT, 'background')
+  this.game.add.tileSprite(0, 0, WORLD_WIDTH, WORLD_HEIGHT, 'background')
 
     // Add the demo tilemap and attach a tilesheet for its collision layer
   this.map = this.game.add.tilemap('tilemap')


### PR DESCRIPTION
It's based on this article http://www.emanueleferonato.com/2017/01/05/optimize-your-phaser-html5-games-on-mobile-devices-by-using-more-sprites-and-less-tilesprites/

I don't see any big difference in performance but it may need more testing

Before:
![screen shot 2017-01-06 at 12 25 43](https://cloud.githubusercontent.com/assets/328414/21716774/e9ff51c4-d40c-11e6-9494-b309c06e922b.png)

After:
![screen shot 2017-01-06 at 12 23 04](https://cloud.githubusercontent.com/assets/328414/21716775/efe23ba6-d40c-11e6-8fdb-7db13561f659.png)

