### PR TITLE
Force unpausing the game after 1 second to prevent loading screen freeze bug

### DIFF
--- a/resources/assets/js/game.js
+++ b/resources/assets/js/game.js
@@ -22,4 +22,7 @@ export default function(store) {
   game.state.add('TeamDeathmatch', RS.TeamDeathmatch)
 
   game.state.start('Boot')
+
+  // force unpausing the game after 1 second to prevent loading screen freeze bug
+  setTimeout(() => game.paused = false, 1000)
 }


### PR DESCRIPTION
With this fix I wasn't able to reproduce that bug anymore (we may need to adjust the timeout in the future)
https://github.com/michaeljcalkins/rangersteve-ideas/issues/189