### PR TITLE
Only allow weapon switching if room state is inactive

### DIFF
--- a/resources/assets/js/lib/CreateHandler/CreateKeyboardBindings.js
+++ b/resources/assets/js/lib/CreateHandler/CreateKeyboardBindings.js
@@ -72,7 +72,8 @@ export default function () {
   this.input.keyboard.addKey(store.getState().game.keyboardControls.switchWeapon).onUp.add(() => {
     if (
       store.getState().player.health <= 0 ||
-      store.getState().player.isSwitchingWeapon
+      store.getState().player.isSwitchingWeapon ||
+      store.getState().room.state !== 'active'
     ) return
 
     // cancel reload action


### PR DESCRIPTION
You just have to try to switch your weapon when the leaderboard is up and it's the end of round.