### PR TITLE
Remove unnecessary spawn point logic

### DIFF
--- a/resources/assets/js/ui/components/GameUi.js
+++ b/resources/assets/js/ui/components/GameUi.js
@@ -25,7 +25,6 @@ import emitMessageSend from '../../lib/SocketEvents/emitMessageSend'
 import RemainingFuelPercent from '../../lib/RemainingFuelPercent'
 import NetworkStats from './NetworkStats/NetworkStats'
 import HudNewChatMessage from './Hud/HudNewChatMessage'
-// import GoogleAd from './GoogleAd/GoogleAd'
 
 export default class GameUi extends Component {
   constructor (props) {
@@ -39,7 +38,7 @@ export default class GameUi extends Component {
 
   startEventHandler () {
     document.addEventListener('keydown', (e) => {
-      const game = this.props.game
+      const { game, onOpenChatModal, onCloseChatModal, onCloseSettingsModal } = this.props
 
       if (
         (
@@ -50,13 +49,13 @@ export default class GameUi extends Component {
         !game.settingsModalIsOpen
       ) {
         e.preventDefault()
-        this.props.onOpenChatModal()
+        onOpenChatModal()
       }
 
       if (e.keyCode === window.Phaser.Keyboard.ESC) {
         e.preventDefault()
-        this.props.onCloseSettingsModal()
-        this.props.onCloseChatModal()
+        onCloseSettingsModal()
+        onCloseChatModal()
       }
     })
   }
@@ -218,23 +217,6 @@ export default class GameUi extends Component {
         { game.showKillConfirmed &&
           <HudKillConfirmed />
         }
-
-        <div style={{opacity: isRespawnModalOpen && !game.settingsModalIsOpen ? '1' : '0'}}>
-          {/* <GoogleAd
-            client='ca-pub-2986206357433139'
-            slot='8388123205'
-            style={{
-              width: 728,
-              height: 90,
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              marginLeft: '-364px',
-              marginTop: '-282px',
-              zIndex: 1000000003
-            }}
-          /> */}
-        </div>
       </div>
     )
   }

--- a/resources/assets/js/ui/components/RespawnModal/RespawnModal.js
+++ b/resources/assets/js/ui/components/RespawnModal/RespawnModal.js
@@ -18,6 +18,7 @@ export class RespawnModal extends PureComponent {
   }
 
   state = {
+    isRespawning: false,
     autoRespawn: this.props.game.autoRespawn,
     oneTimeAutoRespawn: false,
     elapsed: 0,
@@ -30,6 +31,7 @@ export class RespawnModal extends PureComponent {
 
   componentWillUnmount () {
     clearInterval(this.timer)
+    this.setState({ isRespawning: false })
   }
 
   props: {
@@ -38,9 +40,9 @@ export class RespawnModal extends PureComponent {
   }
 
   tick () {
-    const { canRespawnTime } = this.props.player
-    const { currentTime } = this.props.room
-    const timeRemaining = (canRespawnTime / 1000) - (currentTime / 1000)
+    const { player, room } = this.props
+    const { isRespawning } = this.state
+    const timeRemaining = (player.canRespawnTime / 1000) - (room.currentTime / 1000)
     let seconds = Number((timeRemaining).toFixed(1))
     if (seconds % 1 === 0) seconds = seconds + '.0'
 
@@ -52,7 +54,12 @@ export class RespawnModal extends PureComponent {
     }
 
     // Respawn when the wait time has elapsed
-    if ((this.state.autoRespawn || this.state.oneTimeAutoRespawn) && seconds < 0) {
+    if (
+      (this.state.autoRespawn || this.state.oneTimeAutoRespawn) &&
+      seconds <= 0 &&
+      !isRespawning
+    ) {
+      this.setState({ isRespawning: true })
       this.handleRespawnButtonClick()
       return
     }
@@ -158,7 +165,7 @@ export class RespawnModal extends PureComponent {
   }
 
   handleRespawnButtonClick () {
-    Client.send(GameConsts.EVENT.PLAYER_RESPAWN, {})
+    Client.send(GameConsts.EVENT.PLAYER_RESPAWN)
   }
 
   handleWeaponsViewClick (view) {


### PR DESCRIPTION
Fixes two bugs:

- Where when you die your camera moves all over because it receives multiple respawn points
- Sometimes the auto respawn doesn't work because timeRemaining would be 0